### PR TITLE
Ensure that right ctrl and right shift behave the same way as their left counterparts

### DIFF
--- a/Paradox.Console/Console.Definitions.cs
+++ b/Paradox.Console/Console.Definitions.cs
@@ -22,6 +22,7 @@ namespace Varus.Paradox.Console
             { Keys.Up, ConsoleAction.PreviousCommandInHistory },
             { Keys.Down, ConsoleAction.NextCommandInHistory },            
             { Keys.LeftCtrl, ConsoleAction.CopyPasteModifier },
+            { Keys.RightCtrl, ConsoleAction.CopyPasteModifier },
             { Keys.LeftShift, ConsoleAction.PreviousEntryModifier },
             { Keys.RightShift, ConsoleAction.PreviousEntryModifier },
             { Keys.V, ConsoleAction.Paste },
@@ -29,6 +30,7 @@ namespace Varus.Paradox.Console
             //{ Keys.Tab, ConsoleAction.Autocomplete },            
             { Keys.Space, ConsoleAction.Autocomplete },
             { Keys.LeftCtrl, ConsoleAction.AutocompleteModifier },
+            { Keys.RightCtrl, ConsoleAction.AutocompleteModifier },
             { Keys.Tab, ConsoleAction.Tab },
             { Keys.LeftShift, ConsoleAction.TabModifier },
             { Keys.RightShift, ConsoleAction.TabModifier }


### PR DESCRIPTION
Not sure if this was overlooked or omitted ;).
By the way, cool idea. Would be great to see it as a NuGet package one day.
